### PR TITLE
Remove mentioning of `ordering` keyword

### DIFF
--- a/PolynomialRings.ipynb
+++ b/PolynomialRings.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "* Author: Luca Remke\n",
     "* Version: OSCAR version 0.14.0\n",
-    "* Last modified: January 26, 2024"
+    "* Last modified: February 7, 2024"
    ]
   },
   {
@@ -94,12 +94,9 @@
     "\n",
     "| Method |\n",
     "| :----------- |\n",
-    "| `polynomial_ring(C::Ring, var_names::Vector{String}; ordering=:lex, cached = true)` |\n",
+    "| `polynomial_ring(C::Ring, var_names::Vector{String})` |\n",
     "\n",
     "Its return value is a tuple `R, vars` consisting of a polynomial ring `R` with coefficient ring `C` and a vector `vars` of generators corresponding to the strings in vector `var_names`. \n",
-    "\n",
-    "The parameter `ordering` defines the monomial order and is assigned the default value `lex`. \n",
-    "Caching is used to ensure that a constructed ring is unique in the system.\n",
     "\n",
     "Here are a few examples:"
    ]


### PR DESCRIPTION
I removed the explanation of the `ordering` and `cached` keywords in the "Polynomial Rings" tutorial. For a new user these only lead to confusion, see https://github.com/oscar-system/Oscar.jl/issues/3040.
